### PR TITLE
add support for rendering LaneMarkType.SOLID_DASH_WHITE in EgoViewMapRenderer

### DIFF
--- a/src/av2/rendering/map.py
+++ b/src/av2/rendering/map.py
@@ -125,7 +125,7 @@ class EgoViewMapRenderer:
                 dash_interval_m=DASH_INTERVAL_M,
             )
 
-        elif (mark_type == LaneMarkType.SOLID_DASH_YELLOW and side == "right") or (
+        elif (mark_type in [LaneMarkType.SOLID_DASH_WHITE, LaneMarkType.SOLID_DASH_YELLOW] and side == "right") or (
             mark_type == LaneMarkType.DASH_SOLID_YELLOW and side == "left"
         ):
             self.render_polyline_egoview(left, img_bgr, bound_color, thickness_px=line_width_px)
@@ -133,7 +133,7 @@ class EgoViewMapRenderer:
                 right, img_bgr, bound_color, thickness_px=line_width_px, dash_interval_m=DASH_INTERVAL_M
             )
 
-        elif (mark_type == LaneMarkType.SOLID_DASH_YELLOW and side == "left") or (
+        elif (mark_type in [LaneMarkType.SOLID_DASH_WHITE, LaneMarkType.SOLID_DASH_YELLOW] and side == "left") or (
             mark_type == LaneMarkType.DASH_SOLID_YELLOW and side == "right"
         ):
             self.draw_dashed_polyline_egoview(


### PR DESCRIPTION


## PR Summary
Add support for rendering LaneMarkType.SOLID_DASH_WHITE in EgoViewMapRenderer. This is a very rare marking type, but does appear in the AV2 Sensor Dataset.

## Testing
<!-- Authors: Add testing details here, explaining your overall strategy, and check the applicable boxes below. -->

In order to ensure this PR works as intended, it is:

* [ ] unit tested.
* [ ] other or not applicable (*additional detail/rationale required*)

## Compliance with Standards
<!-- Authors: Check each item below to certify that this PR is ready for review. -->

As the author, I certify that this PR conforms to the following standards:

* [X] Code changes conform to [PEP8](https://www.python.org/dev/peps/pep-0008) and docstrings conform to the Google Python [style guide](https://google.github.io/styleguide/pyguide.html?showone=Comments#38-comments-and-docstrings).
* [X] A well-written summary explains what was done and why it was done.
* [X] The PR is adequately tested and the testing details and links to external results are included.

<!-- Authors: If this PR is not ready for review, please create a "Draft Pull Request" using the dropdown below. -->