### PR TITLE
Fix broken link to Argoverse website in motion forecasting readme

### DIFF
--- a/src/av2/datasets/motion_forecasting/README.md
+++ b/src/av2/datasets/motion_forecasting/README.md
@@ -12,7 +12,7 @@ Each scenario is specifically designed to maximize interactions relevant to the 
 
 ## Download
 
-The latest version of the AV2 motion forecasting dataset can be downloaded from the Argoverse [website](https://www.argoverse.org/data.html).
+The latest version of the AV2 motion forecasting dataset can be downloaded from the Argoverse [website](https://www.argoverse.org/av2.html).
 
 ## Scenarios and Tracks
 


### PR DESCRIPTION
## PR Summary
Before linked to
https://www.argoverse.org/data.html
(a dead link). Changed to link to:
https://www.argoverse.org/av2.html

## Testing
<!-- Authors: Add testing details here, explaining your overall strategy, and check the applicable boxes below. -->

In order to ensure this PR works as intended, it is:

* [ ] unit tested.
* [ ] other or not applicable (*additional detail/rationale required*)

## Compliance with Standards
<!-- Authors: Check each item below to certify that this PR is ready for review. -->

As the author, I certify that this PR conforms to the following standards:

* [ ] Code changes conform to [PEP8](https://www.python.org/dev/peps/pep-0008) and docstrings conform to the Google Python [style guide](https://google.github.io/styleguide/pyguide.html?showone=Comments#38-comments-and-docstrings).
* [ ] A well-written summary explains what was done and why it was done.
* [ ] The PR is adequately tested and the testing details and links to external results are included.

<!-- Authors: If this PR is not ready for review, please create a "Draft Pull Request" using the dropdown below. -->