### PR TITLE
Replace TbV gifs to illustrate map changes more clearly

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Please see [DOWNLOAD.md](DOWNLOAD.md) for detailed instructions on how to downlo
 </div>
 
 <div align="center">
-  <h4> <a href="src/av2/datasets/tbv/README.md"> Map Change (Trust, but Verify) </a> </h4>
-  <img src="https://user-images.githubusercontent.com/29715011/159150544-93ed1b7e-242a-416e-ac01-e1df3ff9be8b.gif" height="150">
-  <img src="https://user-images.githubusercontent.com/29715011/159150539-e5d14886-4b5c-4e10-96e1-6fdf5696d430.gif" height="150">
+  <h4> <a href="src/av2/datasets/tbv/README.md"> Map Change Dataset (Trust, but Verify) </a> </h4>
+  <img src="https://user-images.githubusercontent.com/29715011/159289930-a58147c3-c6ed-4b4e-a2a8-e23c23feb43e.gif" height="150">
+  <img src="https://user-images.githubusercontent.com/29715011/159289891-8aae12e7-136a-4f44-bbc1-8ef93f01e23e.gif" height="150">
   <img src="https://user-images.githubusercontent.com/29715011/159152108-3c3001fe-ec7c-48fd-8c08-4a473affb2a3.gif" height="150">
   <img src="https://user-images.githubusercontent.com/29715011/159152102-27c04180-9ca4-4725-be81-95ee6858d367.gif" height="150">
 </div>

--- a/src/av2/datasets/tbv/README.md
+++ b/src/av2/datasets/tbv/README.md
@@ -1,8 +1,8 @@
 # Trust, but Verify (TbV) Dataset Overview
 
 <div align="center">
-  <img src="https://user-images.githubusercontent.com/29715011/159150544-93ed1b7e-242a-416e-ac01-e1df3ff9be8b.gif" height="250">
-  <img src="https://user-images.githubusercontent.com/29715011/159150539-e5d14886-4b5c-4e10-96e1-6fdf5696d430.gif" height="250">
+  <img src="https://user-images.githubusercontent.com/29715011/159289930-a58147c3-c6ed-4b4e-a2a8-e23c23feb43e.gif" height="250">
+  <img src="https://user-images.githubusercontent.com/29715011/159289891-8aae12e7-136a-4f44-bbc1-8ef93f01e23e.gif" height="250">
   <img src="https://user-images.githubusercontent.com/29715011/159152108-3c3001fe-ec7c-48fd-8c08-4a473affb2a3.gif" height="250">
   <img src="https://user-images.githubusercontent.com/29715011/159152102-27c04180-9ca4-4725-be81-95ee6858d367.gif" height="250">
 </div>


### PR DESCRIPTION
## PR Summary
Replaces previous TbV gifs with 2 new gifs, that better illustrate bike-lane map change.

## Testing
<!-- Authors: Add testing details here, explaining your overall strategy, and check the applicable boxes below. -->

In order to ensure this PR works as intended, it is:

* [ ] unit tested.
* [ ] other or not applicable (*additional detail/rationale required*)

## Compliance with Standards
<!-- Authors: Check each item below to certify that this PR is ready for review. -->

As the author, I certify that this PR conforms to the following standards:

* [ ] Code changes conform to [PEP8](https://www.python.org/dev/peps/pep-0008) and docstrings conform to the Google Python [style guide](https://google.github.io/styleguide/pyguide.html?showone=Comments#38-comments-and-docstrings).
* [ ] A well-written summary explains what was done and why it was done.
* [ ] The PR is adequately tested and the testing details and links to external results are included.

<!-- Authors: If this PR is not ready for review, please create a "Draft Pull Request" using the dropdown below. -->